### PR TITLE
Windows fix - add rimraf package

### DIFF
--- a/elm-scripts.js
+++ b/elm-scripts.js
@@ -6,7 +6,7 @@ var exec = Promise.promisify(require('child_process').exec)
 process.chdir('lib/compilers/elm-compiler/temp')
 var elmPackageJson = require(path.join(process.cwd(), 'elm-package-template.js'))
 
-exec('rm -rf elm-stuff elm-package.json')
+exec('rimraf elm-stuff elm-package.json')
 .then(() => writeFile('elm-package.json', JSON.stringify(elmPackageJson)))
 .then(() => exec('elm-package install -y'))
 .then(console.log)

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "ps-node": "^0.1.2",
     "react-elm-components": "1.0.0",
     "react-for-atom": "15.3.1-0",
+    "rimraf": "^2.5.4",
     "rxjs": "5.0.0-beta.12"
   },
   "package-deps": [


### PR DESCRIPTION
Changed from rm -rf to use rimraf package. Fix #7. Was able to run npm install on my windows machine.
