### PR TITLE
proof of concept: use local elm-packages.json if available

### DIFF
--- a/lib/compilers/elm-compiler/index.js
+++ b/lib/compilers/elm-compiler/index.js
@@ -140,7 +140,7 @@ function resultToComponent(expressions, results) {
 function compileElmFiles(expressions) {
   const allPromises = expressions.map((expression) => {
     const fileName = `F${expression.hash}`
-    return promisifiedExec(`cd ${codePath} && elm-make --yes ${fileName}.elm --output=${fileName}.js`)
+    return promisifiedExec(`cd ${codePath} && elm-package install -y && elm-make --yes ${fileName}.elm --output=${fileName}.js`)
   })
 
   return allPromises
@@ -164,7 +164,11 @@ export function compile(code: string = '', playgroundCode: string = '', openFile
 
   subscriber.next({compiling: true})
 
-  return updateFileSources(openFileFolderPath, lastOpenFilePath, packageJsonTemplateFileContents)
+  const projectPackageJsonPath = openFileFolderPath + '/' + 'elm-package.json'
+  const packageJsonProjectContents = fs.existsSync(projectPackageJsonPath) ? JSON.parse(fs.readFileSync(projectPackageJsonPath)) : null
+  const packageJson = packageJsonProjectContents || packageJsonTemplateFileContents
+
+  return updateFileSources(openFileFolderPath, lastOpenFilePath, packageJson)
     .then(() => writeCodeToFile(code))
     .then((userModuleName) => writeFilesForExpressions(tokensWithHashes, userModuleName, codePath, notInCache))
     .then((expressions) => ({allPromises: compileElmFiles(expressions), expressions}))


### PR DESCRIPTION
This is more like a proof of concept than code that's ready (I don't know javascript well enough). But the main idea is instead of hardcoding the dependencies, it should use the dependencies from the project that's open.

My attempt at discovering the elm-packages.json file is pretty naive, it only looks in the current directory of the open file.